### PR TITLE
Fixed syntax in index.d.ts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,7 +5,7 @@ declare module "parse-css-color" {
     readonly alpha: number
     readonly type: string
     readonly values: number[]
-  } | null
+  }
 
-  function parseCSSColor(str: string): Result
+  function parseCSSColor(str: string): Result | null
 }


### PR DESCRIPTION
`interface Result { [...] } | null` is not valid syntax for typescript interfaces.

You either want it to be a `type Result = { [...] } | null`, or just specify `Result | null` in the return of the function.

In this PR I opted for the latter.